### PR TITLE
feat: implement critical user registration api tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,73 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Mac
+.DS_Store
+
+# Allure
+allure_report
+
+# Config
+configs.py

--- a/framework/asserts/registration_asserts.py
+++ b/framework/asserts/registration_asserts.py
@@ -1,12 +1,13 @@
 from hamcrest import assert_that, is_
+import bcrypt
 
 
 def check_mapping_api_to_db(api_request: dict, database_data: dict) -> None:
-    """Checking the mapping of data from the request API to database
+    """Checking the mapping of data from the request API to the database
 
     Args:
-        api_request:    reference data, data from an API-request;
-        database_data:  compared data, data from database.
+        api_request:    reference data, data from an API request;
+        database_data:  compared data, data from the database (a dictionary).
     """
     fields_api_to_db = {
         "email": "email",
@@ -14,9 +15,19 @@ def check_mapping_api_to_db(api_request: dict, database_data: dict) -> None:
         "lastName": "last_name",
         "password": "password",
     }
+
     for key_api, key_db in fields_api_to_db.items():
-        assert_that(
-            api_request[key_api],
-            is_(database_data[key_db]),
-            reason=f'"{key_db}" not equal expected',
-        )
+        if key_api == "password":
+            # Hash the password from the API request
+            hashed_password = bcrypt.hashpw(api_request[key_api].encode('utf-8'), database_data[key_db].encode('utf-8'))
+            assert_that(
+                hashed_password.decode('utf-8'),
+                is_(database_data[key_db]),
+                reason=f'"{key_db}" not equal expected',
+            )
+        else:
+            assert_that(
+                api_request[key_api],
+                is_(database_data[key_db]),
+                reason=f'"{key_db}" not equal expected',
+            )

--- a/tests/registration/test_registration.py
+++ b/tests/registration/test_registration.py
@@ -1,5 +1,8 @@
+import allure
+import pytest
 from allure import description, feature, link, step, title
-from hamcrest import assert_that, is_
+from allure_commons._allure import severity
+from hamcrest import assert_that, is_, has_length, has_key, is_not, empty
 
 from framework.asserts.registration_asserts import check_mapping_api_to_db
 from framework.endpoints.authenticate_api import AuthenticateAPI
@@ -13,35 +16,114 @@ from framework.tools.generators import generate_string
     name="(!) WAIT LINK. Description of the tested functionality",
 )
 class TestRegistration:
-    @title("User registration under minimum requirements")
-    @description(
-        "WHEN the user submits the minimum required data for registration, "
-        "THEN the information about the user is stored in the database"
-    )
-    def test_of_registration(self, postgres):
+    def setup_method(self):
         with step("Generation data for registration"):
-            email = generate_string(length=2, additional_characters=["@te.st"])
+            self.email = generate_string(length=10, additional_characters=["@te.st"])
             first_name = generate_string(length=2)
             last_name = generate_string(length=2)
             password = generate_string(
                 length=8, additional_characters=["@1"]
             ).capitalize()
 
-            body = RegistrationSteps().data_for_sent(
-                email=email,
+            self.user_to_register = RegistrationSteps().data_for_sent(
+                email=self.email,
                 first_name=first_name,
                 last_name=last_name,
                 password=password,
             )
 
-        with step("Registration of user"):
-            response_registration = AuthenticateAPI().registration(body=body)
-            assert_that(response_registration.status_code, is_(201))
+        self.registration_response = None
+
+    @allure.step("Registration of user")
+    def _register_user(self, user):
+        """Registration of user"""
+        self.registration_response = AuthenticateAPI().registration(body=user)
+
+    @severity(severity_level="CRITICAL")
+    @title("User registration under minimum requirements")
+    @description(
+        "WHEN the user submits the minimum required data for registration, "
+        "THEN the information about the user is stored in the database"
+    )
+    def test_of_registration(self, postgres):
+        self._register_user(self.user_to_register)
+
+        with step("Checking the response code"):
+            assert_that(self.registration_response.status_code, is_(201))
+
+        with step("Checking the response body"):
+            response_json = self.registration_response.json()
+            assert_that(response_json, has_key("token"))
+            assert_that(response_json["token"], is_not(empty()))
 
         with step("Getting info about the user in DB"):
             user_data = postgres.get_data_by_filter(
-                table="user_details", field="email", value=email
+                table="user_details", field="email", value=self.email
             )
 
         with step("Checking mapping data from the API request to the database"):
-            check_mapping_api_to_db(api_request=body, database_data=user_data[0])
+            check_mapping_api_to_db(api_request=self.user_to_register, database_data=user_data[0])
+
+    @severity(severity_level="MAJOR")
+    @title("User registration with not unique email")
+    @description(
+        "WHEN the user submits data with a non-unique email for registration, "
+        "THEN the user receives an error message, and the user's information is not stored in the database"
+    )
+    def test_of_registration_email_uniqueness(self, postgres):
+        self._register_user(self.user_to_register)
+
+        self._register_user(self.user_to_register)
+
+        with step("Checking the response code"):
+            assert_that(self.registration_response.status_code, is_(400))
+
+        with step("Checking the response body"):
+            expected_message = 'Email must be unique'
+            response_json = self.registration_response.json()
+            assert_that(response_json, has_key("message"))
+            assert_that(response_json["message"][0], is_(expected_message))
+
+        with step("Getting info about the user with not unique email in DB"):
+            user_data = postgres.get_data_by_filter(
+                table="user_details", field="email", value=self.email
+            )
+
+        with step("Checking that new user with duplicate email has not been registered "):
+            assert_that(user_data, has_length(1))
+            check_mapping_api_to_db(api_request=self.user_to_register, database_data=user_data[0])
+
+    fields = [
+        ("email", "Email should have a length between 2 and 128 characters"),
+        ("firstName", "First name is the mandatory attribute"),
+        ("lastName", "Last name is the mandatory attribute"),
+        ("password", "Password is the mandatory attribute")
+    ]
+
+    @pytest.mark.parametrize("data", fields)
+    @severity(severity_level="MAJOR")
+    @title("User registration with missing required field")
+    @description(
+        f"WHEN the user submits data with a missing required field for registration, "
+        "THEN the user receives an error message, and the user's information is not stored in the database"
+    )
+    def test_of_registration_required_fields(self, postgres, data):
+        [field, expected_message] = data
+        self.user_to_register.pop(field)
+
+        self._register_user(self.user_to_register)
+
+        with step("Checking the response code"):
+            assert_that(self.registration_response.status_code, is_(400))
+
+        with step("Checking the response body"):
+
+            response_json = self.registration_response.json()
+            assert_that(response_json, has_key("message"))
+            assert_that(response_json["message"][0], is_(expected_message))
+
+        with step(f"Checking that new user with missing field {field} has not been registered "):
+            user_data = postgres.get_data_by_filter(
+                table="user_details", field="email", value=self.email
+            )
+            assert_that(user_data, has_length(0))


### PR DESCRIPTION
1. Add critical api tests for user registration endpoint: 

- register with valid credentials
- register with non-unique email
- register with missing mandatory field

2. Fix the check_mapping_api_to_db method in [framework/asserts/registration_asserts.py]:  add when `key_api` is "password," the code now hashes the password from the API request and compares it to the hashed password in the database. 

3. Add .gitignore