### PR TITLE
[IL-239]Cover endpoint Cart with autotests

### DIFF
--- a/framework/endpoints/cart_api.py
+++ b/framework/endpoints/cart_api.py
@@ -4,6 +4,7 @@ import requests
 from requests import Response
 
 from configs import HOST
+from framework.asserts.common import assert_status_code
 
 from framework.tools.logging import log_request
 
@@ -25,17 +26,16 @@ class CartAPI:
         headers["Authorization"] = f"Bearer {token}"
         path = self.url
         response = requests.get(url=path, headers=headers)
-        assert_that(response.status_code, is_(expected_status_code),
-                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
 
         return response
 
-    def delete_item_from_cart(self, token: str, body: dict, expected_status_code: int = 200) -> Response:
+    def delete_item_from_cart(self, token: str, item_to_delete: dict, expected_status_code: int = 200) -> Response:
         """Deleting item from shopping cart
 
         Args:
-            body:  data for deleting items from shopping cart with required fields
+            item_to_delete:  data for deleting items from shopping cart with required fields
                   {
                     "shoppingCartItemIds": ["CartItemId"]
 
@@ -43,41 +43,34 @@ class CartAPI:
             expected_status_code: expected http status code from response
             token: JWT token for authorization of request
         """
-
         headers = self.headers
         headers["Authorization"] = f"Bearer {token}"
         path = self.url + "/items"
-        response = requests.delete(url=path, headers=headers, data=json.dumps(body))
-        assert_that(response.status_code, is_(expected_status_code),
-                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        response = requests.delete(url=path, headers=headers, data=json.dumps(item_to_delete))
+        assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
 
         return response
 
-    def update_quantity_product(self, token: str, item_id: str, quantity: int,
+    def update_quantity_product(self, token: str, item_to_update: dict,
                                 expected_status_code: int = 200) -> Response:
         """Updating product's quantity
 
-                Args:
-                    expected_status_code: expected http status code from response
-                    token: JWT token for authorization of request
-                    item_id: product id to update
-                    quantity: quantity of product for updating
-
-                """
-
-        data = {
-            "shoppingCartItemId": item_id,
-            "productQuantityChange": quantity
-        }
+        Args:
+            expected_status_code: expected http status code from response
+            token: JWT token for authorization of request
+            item_to_update: shopping cart Item id and quantity to update
+                           {
+                             "shoppingCartItemId": item_id,
+                            "productQuantityChange": quantity
+                           }
+        """
         headers = self.headers
         headers["Authorization"] = f"Bearer {token}"
         path = self.url + "/items"
-        response = requests.patch(url=path, data=json.dumps(data), headers=headers)
-        assert_that(response.status_code, is_(expected_status_code),
-                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        response = requests.patch(url=path, data=json.dumps(item_to_update), headers=headers)
+        assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
-
         return response
 
     def add_new_item_to_cart(self, token: str, items: list, expected_status_code: int = 200) -> Response:
@@ -94,13 +87,11 @@ class CartAPI:
                 {"productId": "6788gg-uh8-hajj6", "productQuantity": 3}
             ]
         """
-
         headers = self.headers
         headers["Authorization"] = f"Bearer {token}"
         path = self.url + "/items"
         body = {"items": items}
         response = requests.post(url=path, data=json.dumps(body), headers=headers)
-        assert_that(response.status_code, is_(expected_status_code),
-                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
         return response

--- a/framework/endpoints/cart_api.py
+++ b/framework/endpoints/cart_api.py
@@ -1,0 +1,106 @@
+import json
+from hamcrest import assert_that, is_
+import requests
+from requests import Response
+
+from configs import HOST
+
+from framework.tools.logging import log_request
+
+
+class CartAPI:
+    def __init__(self):
+        """Initializing parameters for request"""
+        self.url = HOST + "/api/v1/cart"
+        self.headers = {"Content-Type": "application/json"}
+
+    def get_user_cart(self, token: str, expected_status_code: int = 200) -> Response:
+        """ Getting info about user's shopping cart
+
+        Args:
+            expected_status_code: expected http status code from response
+            token: JWT token for authorization of request
+        """
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        path = self.url
+        response = requests.get(url=path, headers=headers)
+        assert_that(response.status_code, is_(expected_status_code),
+                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        log_request(response)
+
+        return response
+
+    def delete_item_from_cart(self, token: str, body: dict, expected_status_code: int = 200) -> Response:
+        """Deleting item from shopping cart
+
+        Args:
+            body:  data for deleting items from shopping cart with required fields
+                  {
+                    "shoppingCartItemIds": ["CartItemId"]
+
+                  }
+            expected_status_code: expected http status code from response
+            token: JWT token for authorization of request
+        """
+
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        path = self.url + "/items"
+        response = requests.delete(url=path, headers=headers, data=json.dumps(body))
+        assert_that(response.status_code, is_(expected_status_code),
+                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        log_request(response)
+
+        return response
+
+    def update_quantity_product(self, token: str, item_id: str, quantity: int,
+                                expected_status_code: int = 200) -> Response:
+        """Updating product's quantity
+
+                Args:
+                    expected_status_code: expected http status code from response
+                    token: JWT token for authorization of request
+                    item_id: product id to update
+                    quantity: quantity of product for updating
+
+                """
+
+        data = {
+            "shoppingCartItemId": item_id,
+            "productQuantityChange": quantity
+        }
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        path = self.url + "/items"
+        response = requests.patch(url=path, data=json.dumps(data), headers=headers)
+        assert_that(response.status_code, is_(expected_status_code),
+                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        log_request(response)
+
+        return response
+
+    def add_new_item_to_cart(self, token: str, items: list, expected_status_code: int = 200) -> Response:
+        """Adding multiple products to cart and verifying if they are in the response
+
+        Args:
+            items: A list of items where each item is a dictionary containing 'productId' and 'productQuantity'
+            expected_status_code (int): Expected HTTP status code from response
+            token (str): JWT token for authorization of request
+
+        Example:
+            items = [
+                {"productId": "123ffg-333-jjj78", "productQuantity": 2},
+                {"productId": "6788gg-uh8-hajj6", "productQuantity": 3}
+            ]
+        """
+
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        path = self.url + "/items"
+        body = {"items": items}
+        response = requests.post(url=path, data=json.dumps(body), headers=headers)
+        assert_that(response.status_code, is_(expected_status_code),
+                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        log_request(response)
+        return response

--- a/framework/endpoints/cart_api.py
+++ b/framework/endpoints/cart_api.py
@@ -31,44 +31,24 @@ class CartAPI:
 
         return response
 
-    def delete_item_from_cart(self, token: str, item_to_delete: dict, expected_status_code: int = 200) -> Response:
-        """Deleting item from shopping cart
-
-        Args:
-            item_to_delete:  data for deleting items from shopping cart with required fields
-                  {
-                    "shoppingCartItemIds": ["CartItemId"]
-
-                  }
-            expected_status_code: expected http status code from response
-            token: JWT token for authorization of request
-        """
-        headers = self.headers
-        headers["Authorization"] = f"Bearer {token}"
-        path = self.url + "/items"
-        response = requests.delete(url=path, headers=headers, data=json.dumps(item_to_delete))
-        assert_status_code(response, expected_status_code=expected_status_code)
-        log_request(response)
-
-        return response
-
-    def update_quantity_product(self, token: str, item_to_update: dict,
+    def update_quantity_product(self, token: str, item_id: str, item_quantity: int,
                                 expected_status_code: int = 200) -> Response:
         """Updating product's quantity
 
         Args:
+            item_quantity: quantity to update
+            item_id: item to update
             expected_status_code: expected http status code from response
             token: JWT token for authorization of request
-            item_to_update: shopping cart Item id and quantity to update
-                           {
-                             "shoppingCartItemId": item_id,
-                            "productQuantityChange": quantity
-                           }
         """
+        body = {"shoppingCartItemId": item_id,
+                "productQuantityChange": item_quantity
+
+                }
         headers = self.headers
         headers["Authorization"] = f"Bearer {token}"
         path = self.url + "/items"
-        response = requests.patch(url=path, data=json.dumps(item_to_update), headers=headers)
+        response = requests.patch(url=path, data=json.dumps(body), headers=headers)
         assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
         return response
@@ -94,4 +74,26 @@ class CartAPI:
         response = requests.post(url=path, data=json.dumps(body), headers=headers)
         assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
+        return response
+
+    def delete_item_from_cart(self, token: str, cart_item_id: list, expected_status_code: int = 200) -> Response:
+        """Deleting item from shopping cart
+
+        Args:
+            cart_item_id:  data for deleting items from shopping cart with required fields
+            expected_status_code: expected http status code from response
+            token: JWT token for authorization of request
+        """
+
+        body = {
+            "shoppingCartItemIds": cart_item_id
+
+        }
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        path = self.url + "/items"
+        response = requests.delete(url=path, headers=headers, data=json.dumps(body))
+        assert_status_code(response, expected_status_code=expected_status_code)
+        log_request(response)
+
         return response

--- a/framework/endpoints/users_api.py
+++ b/framework/endpoints/users_api.py
@@ -1,8 +1,8 @@
 import requests
-from hamcrest import assert_that, is_
 from requests import Response
 
 from configs import HOST
+from framework.asserts.common import assert_status_code
 from framework.tools.logging import log_request
 
 
@@ -30,11 +30,11 @@ class UsersAPI:
         Args:
             expected_status_code: Expected HTTP code from Response
             token: JWT token for authorization of request
+
         """
         headers = self.headers
         headers["Authorization"] = f"Bearer {token}"
         response = requests.delete(headers=headers, url=self.url)
-        assert_that(response.status_code, is_(expected_status_code),
-                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        assert_status_code(response, expected_status_code=expected_status_code)
         log_request(response)
         return response

--- a/framework/endpoints/users_api.py
+++ b/framework/endpoints/users_api.py
@@ -1,4 +1,5 @@
 import requests
+from hamcrest import assert_that, is_
 from requests import Response
 
 from configs import HOST
@@ -21,4 +22,19 @@ class UsersAPI:
         response = requests.get(headers=headers, url=self.url)
         log_request(response)
 
+        return response
+
+    def delete_user(self, token: str, expected_status_code: int = 200) -> Response:
+        """ Deleting user
+
+        Args:
+            expected_status_code: Expected HTTP code from Response
+            token: JWT token for authorization of request
+        """
+        headers = self.headers
+        headers["Authorization"] = f"Bearer {token}"
+        response = requests.delete(headers=headers, url=self.url)
+        assert_that(response.status_code, is_(expected_status_code),
+                    reason=f"Expected status code {expected_status_code}, found: {response.status_code}")
+        log_request(response)
         return response

--- a/framework/tools/methods_to_cart.py
+++ b/framework/tools/methods_to_cart.py
@@ -1,6 +1,7 @@
-from typing import List, Dict
-
-from hamcrest import assert_that, equal_to, has_key
+import random
+from typing import List, Dict, Any, Union
+from hamcrest import assert_that, equal_to, has_key, not_, has_items, is_not, has_item, is_in
+from requests import Response
 
 
 def get_product_info(response) -> List[Dict]:
@@ -44,7 +45,7 @@ def assert_compare_product_to_add_with_response(add_product: List[Dict], expecte
                     f"Quantity mismatch for product {expected_id}: Expected {expected_quantity}, found {matching_product['productQuantity']} in add_product")
 
 
-def get_item_id(response) -> Dict:
+def get_item_id(response) -> Union[dict, list]:
     """ Gets item id from a JSON response.
 
     Args:
@@ -64,10 +65,10 @@ def get_item_id(response) -> Dict:
         if item_id := item.get('id'):
             extracted_ids.append(item_id)
 
-    return {"shoppingCartItemIds": extracted_ids}
+    return extracted_ids
 
 
-def get_define_quantity_items_id(response, num_items_to_delete: int) -> Dict:
+def get_define_quantity_items_id(response: Response, num_items_to_delete: int) -> Dict:
     """ Gets item ids from a JSON response.
     Args:
        num_items_to_delete: the quantity of items for delete
@@ -90,3 +91,71 @@ def get_define_quantity_items_id(response, num_items_to_delete: int) -> Dict:
     if num_items_to_delete > 0:
         extracted_ids = extracted_ids[:num_items_to_delete]
     return {"shoppingCartItemIds": extracted_ids}
+
+
+def extract_items_details(response: Response) -> Union[dict, list]:
+    """ Extracts item ID and product quantity from each item in the given JSON response.
+
+    Args:
+        response: The JSON response containing item details.
+    """
+    try:
+        json_response = response.json()
+    except ValueError:
+        return {"error": "Invalid JSON response"}
+
+    extracted_details = []
+
+    for item in json_response.get('items', []):
+        item_id = item.get('id', '')
+        product_quantity = item.get('productQuantity', 0)
+        extracted_details.append((item_id, product_quantity))
+
+    return extracted_details
+
+
+def extract_random_item_detail(response: Response) -> Dict:
+    """ Extracts item ID and product quantity of a randomly selected item from the JSON response.
+
+    Args:
+        response: The JSON response containing item details.
+
+   """
+    try:
+        json_response = response.json()
+    except ValueError:
+        return {"error": "Invalid JSON response"}
+
+    items = json_response.get('items', [])
+
+    if not items:
+        raise ValueError("No items found in the JSON response.")
+
+    random_item = random.choice(items)
+    item_id = random_item.get('id', '')
+    product_quantity = random_item.get('productQuantity', 0)
+    return {
+        "id": item_id,
+        "productQuantity": product_quantity
+    }
+
+
+def get_quantity_specific_cart_item(response: Response, specific_item_id: str) -> Any:
+    """ Extracts the quantity of a specific item from json response based on the provided specific ID.
+    Args:
+        response: The JSON response from request.
+        specific_item_id: The specific ID of the item to find.
+
+    Return: The quantity of the item with the specific ID, or a message if not found.
+    """
+    try:
+        json_response = response.json()
+    except ValueError:
+        return {"error": "Invalid JSON response"}
+    data = json_response.get("items", [])
+    for item in data:
+        if item.get('id') == specific_item_id:
+            return item.get('productQuantity')
+    return f"Item with ID {specific_item_id} not found."
+
+

--- a/framework/tools/methods_to_cart.py
+++ b/framework/tools/methods_to_cart.py
@@ -1,0 +1,89 @@
+from hamcrest import assert_that, equal_to, has_key
+
+
+def verify_products_in_response(response) -> list:
+    """Extracts product info from a response.
+
+    Iterates through the items in the response and extracts the product ID,
+    quantity for each item into a list of dictionaries.
+
+    Args:
+       response: The response to extract products from
+
+    """
+
+    response_data = response.json()
+    extracted_products = []
+
+    for item in response_data["items"]:
+        product = item["productInfo"]
+        product_info = {
+            "id": product["id"],
+            "productQuantity": item["productQuantity"]
+        }
+
+        extracted_products.append(product_info)
+    return extracted_products
+
+
+def assert_compare_product_to_add_with_response(add_product: list[dict], expected_product: list[dict]):
+    """ Assertion that product were added to the shopping cart
+
+    Args:
+        add_product: list of products to add to the user's shopping cart
+        expected_product: expected products from response
+    """
+    add_product_dict = {product['productId']: product for product in add_product}
+
+    for expected in expected_product:
+        expected_id = expected['id']
+        expected_quantity = expected['productQuantity']
+
+        assert_that(add_product_dict, has_key(expected_id),
+                    f"Expected product with ID {expected_id} not found in add_product")
+
+        matching_product = add_product_dict[expected_id]
+        assert_that(matching_product['productQuantity'], equal_to(expected_quantity),
+                    f"Quantity mismatch for product {expected_id}: Expected {expected_quantity}, found {matching_product['productQuantity']} in add_product")
+
+
+def extract_item_id(response):
+    try:
+        response_data = response.json()
+    except ValueError:
+
+        return {"error": "Invalid JSON response"}
+
+    extracted_ids = []
+
+    for item in response_data.get('items', []):
+        item_id = item.get('id')
+        if item_id:
+            extracted_ids.append(item_id)
+
+    return {"shoppingCartItemIds": extracted_ids}
+
+
+def extract_define_quantity_items_id(response, num_items_to_delete=None):
+    # Initialize an empty list to store the extracted information
+    try:
+        response_data = response.json()
+    except ValueError:
+        # Handle cases where JSON decoding fails
+        return {"error": "Invalid JSON response"}
+
+    extracted_ids = []
+
+    # Iterate through each item in the 'items' list
+    for item in response_data.get('items', []):
+        # Extract item ID and add to the list
+        item_id = item.get('id')
+        if item_id:
+            extracted_ids.append(item_id)
+
+    if num_items_to_delete is not None:
+        extracted_ids = extracted_ids[:num_items_to_delete]
+    return {"shoppingCartItemIds": extracted_ids}
+
+
+

--- a/framework/tools/methods_to_cart.py
+++ b/framework/tools/methods_to_cart.py
@@ -1,17 +1,14 @@
+from typing import List, Dict
+
 from hamcrest import assert_that, equal_to, has_key
 
 
-def verify_products_in_response(response) -> list:
-    """Extracts product info from a response.
-
-    Iterates through the items in the response and extracts the product ID,
-    quantity for each item into a list of dictionaries.
+def get_product_info(response) -> List[Dict]:
+    """Extracts product info (ID and quantity) from a response.
 
     Args:
-       response: The response to extract products from
-
+       response: The JSON response.
     """
-
     response_data = response.json()
     extracted_products = []
 
@@ -26,7 +23,7 @@ def verify_products_in_response(response) -> list:
     return extracted_products
 
 
-def assert_compare_product_to_add_with_response(add_product: list[dict], expected_product: list[dict]):
+def assert_compare_product_to_add_with_response(add_product: List[Dict], expected_product: List[Dict]):
     """ Assertion that product were added to the shopping cart
 
     Args:
@@ -47,7 +44,14 @@ def assert_compare_product_to_add_with_response(add_product: list[dict], expecte
                     f"Quantity mismatch for product {expected_id}: Expected {expected_quantity}, found {matching_product['productQuantity']} in add_product")
 
 
-def extract_item_id(response):
+def get_item_id(response) -> Dict:
+    """ Gets item id from a JSON response.
+
+    Args:
+        response: The JSON response to extract ids from.
+    Raises:
+        ValueError: If JSON decoding of response fails.
+    """
     try:
         response_data = response.json()
     except ValueError:
@@ -57,33 +61,32 @@ def extract_item_id(response):
     extracted_ids = []
 
     for item in response_data.get('items', []):
-        item_id = item.get('id')
-        if item_id:
+        if item_id := item.get('id'):
             extracted_ids.append(item_id)
 
     return {"shoppingCartItemIds": extracted_ids}
 
 
-def extract_define_quantity_items_id(response, num_items_to_delete=None):
-    # Initialize an empty list to store the extracted information
+def get_define_quantity_items_id(response, num_items_to_delete: int) -> Dict:
+    """ Gets item ids from a JSON response.
+    Args:
+       num_items_to_delete: the quantity of items for delete
+       response: The JSON response to extract ids from.
+    Raises:
+       ValueError: If JSON decoding of response fails.
+    """
+
     try:
         response_data = response.json()
     except ValueError:
-        # Handle cases where JSON decoding fails
         return {"error": "Invalid JSON response"}
 
     extracted_ids = []
 
-    # Iterate through each item in the 'items' list
     for item in response_data.get('items', []):
-        # Extract item ID and add to the list
-        item_id = item.get('id')
-        if item_id:
+        if item_id := item.get('id'):
             extracted_ids.append(item_id)
 
-    if num_items_to_delete is not None:
+    if num_items_to_delete > 0:
         extracted_ids = extracted_ids[:num_items_to_delete]
     return {"shoppingCartItemIds": extracted_ids}
-
-
-

--- a/tests/authentication/test_authentication_invalid_credential.py
+++ b/tests/authentication/test_authentication_invalid_credential.py
@@ -39,11 +39,6 @@ class TestAuthentication:
                 response.status_code, is_(401), reason="Expected status code 401"
             )
 
-    @pytest.mark.skip(
-        reason="Bug in the API => wrong authentication response status code. "
-        "Expected status code = 401"
-        "Actual status code = 403"
-    )
     def test_authentication_incorrect_email(self):
         with step("Generation data for registration"):
             data = generate_user_data(
@@ -68,11 +63,6 @@ class TestAuthentication:
                 response.status_code, is_(401), reason="Expected status code 401"
             )
 
-    @pytest.mark.skip(
-        reason="Bug in the API => wrong authentication response status code. "
-        "Expected status code = 401"
-        "Actual status code = 403"
-    )
     def test_authentication_incorrect_password_email(self):
         with step("Generation data for registration"):
             data = generate_user_data(

--- a/tests/cart/test_add_item_to_cart_positive.py
+++ b/tests/cart/test_add_item_to_cart_positive.py
@@ -42,6 +42,3 @@ class TestCart:
             product_list_after_add = get_product_info(response=response_get_cart_after_add)
             assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
             assert_content_type(response_get_cart, "application/json")
-
-
-

--- a/tests/cart/test_add_item_to_cart_positive.py
+++ b/tests/cart/test_add_item_to_cart_positive.py
@@ -1,0 +1,53 @@
+from allure import description, step, title, feature
+from hamcrest import assert_that, is_
+
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+from framework.endpoints.users_api import UsersAPI
+from framework.tools.methods_to_cart import assert_compare_product_to_add_with_response, \
+    verify_products_in_response
+
+
+@feature("Adding items to cart ")
+class TestCart:
+    @title("Test add items to new user's cart")
+    @description(
+        "GIVEN user is registered and does not have shopping cart"
+        "WHEN user add the items to the cart"
+        "THEN status HTTP CODE = 200"
+        "And response body that contain added items returns"
+    )
+    def test_adding_item_to_cart(self, creating_user_via_api):
+        token, new_user_id = creating_user_via_api
+
+        with step("Get shopping cart of user and verify that user doesn't have a shopping cart"):
+            response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
+
+        with step("Checking the response body and the Content-Type"):
+            expected_message = f'The shopping cart for the user with id = {new_user_id} is not found.'
+            assert_response_message(response_get_cart, expected_message)
+            assert_content_type(response_get_cart, "application/json")
+
+        with step("Generation data for adding to the shopping cart"):
+            items_to_add = [
+                {"productId": "ad0ef2b7-816b-4a11-b361-dfcbe705fc96", "productQuantity": 2},
+                {"productId": "3ea8e601-24c9-49b1-8c65-8db8b3a5c7a3", "productQuantity": 3}
+            ]
+
+        with step("Adding new product to a shopping cart "):
+            CartAPI().add_new_item_to_cart(token=token,
+                                           items=items_to_add)
+
+        with step("Checking: 1. The shopping cart created under new user. 2.Added products are in a shopping cart"):
+            response_get_cart_after_add = CartAPI().get_user_cart(token=token)
+            expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
+            assert_that(expected_user_id_in_cart), is_(new_user_id)
+            product_list_after_add = verify_products_in_response(response=response_get_cart_after_add)
+            assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
+
+        with step("Deleting user"):
+            UsersAPI().delete_user(token=token)
+            response_after_del = UsersAPI().get_user(token=token)
+            expected_message_after_del_user = 'User with the provided email does not exist'
+            assert_response_message(response_after_del, expected_message_after_del_user, )
+

--- a/tests/cart/test_delete_items_from_cart.py
+++ b/tests/cart/test_delete_items_from_cart.py
@@ -1,0 +1,62 @@
+from allure import description, step, title, feature
+from hamcrest import assert_that, is_
+
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+from framework.endpoints.users_api import UsersAPI
+from framework.tools.methods_to_cart import verify_products_in_response, \
+    assert_compare_product_to_add_with_response, extract_item_id
+
+
+@feature("Deleting items from cart ")
+class TestCart:
+    @title("Test deleting ALL items from new user's cart")
+    @description(
+        "GIVEN user is registered and  has shopping cart"
+        "WHEN user delete ALL items from  cart"
+        "THEN status HTTP CODE = 200"
+    )
+    def test_deleting_item_from_cart(self, creating_user_via_api):
+        token, new_user_id = creating_user_via_api
+
+        with step("Get shopping cart of user and verify that user doesn't have a shopping cart"):
+            response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
+
+        with step("Checking the response body and Content-Type"):
+            expected_message = f'The shopping cart for the user with id = {new_user_id} is not found.'
+            assert_response_message(response_get_cart, expected_message)
+            assert_content_type(response_get_cart, "application/json")
+
+        with step("Generation data for adding to the shopping cart"):
+            items_to_add = [
+                {"productId": "ad0ef2b7-816b-4a11-b361-dfcbe705fc96", "productQuantity": 2},
+                {"productId": "3ea8e601-24c9-49b1-8c65-8db8b3a5c7a3", "productQuantity": 3}
+            ]
+
+        with step("Adding products to the shopping cart "):
+            CartAPI().add_new_item_to_cart(token=token,
+                                           items=items_to_add)
+
+        with step("Checking: 1. The shopping cart created under new user. 2.Added products are in the shopping cart"):
+            response_get_cart_after_add = CartAPI().get_user_cart(token=token)
+            expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
+            assert_that(expected_user_id_in_cart), is_(new_user_id)
+            product_list_after_add = verify_products_in_response(response=response_get_cart_after_add)
+            assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
+
+        with step("Generating data for delete"):
+            item_to_delete_more_than_one = extract_item_id(response_get_cart_after_add)
+
+        with step("Deleting items from the shopping cart"):
+            response_delete_item = CartAPI().delete_item_from_cart(token=token,
+                                                                   body=item_to_delete_more_than_one)
+            print(response_delete_item.json()["closedAt"])
+
+        with step("Checking the response and Content-Type"):
+            assert_content_type(response_delete_item, "application/json")
+
+        with step("Deleting user"):
+            UsersAPI().delete_user(token=token)
+            response_get_user_after_del = UsersAPI().get_user(token=token)
+            assert_that(response_get_user_after_del.status_code, is_(401))
+            CartAPI().get_user_cart(token=token, expected_status_code=401)

--- a/tests/cart/test_delete_items_from_cart.py
+++ b/tests/cart/test_delete_items_from_cart.py
@@ -1,9 +1,9 @@
 from allure import description, step, title, feature
 from hamcrest import assert_that, is_
 
+from configs import data_for_adding_product_to_cart
 from framework.asserts.common import assert_response_message, assert_content_type
 from framework.endpoints.cart_api import CartAPI
-from framework.endpoints.users_api import UsersAPI
 from framework.tools.methods_to_cart import get_product_info, \
     assert_compare_product_to_add_with_response, get_item_id
 
@@ -28,32 +28,21 @@ class TestCart:
             assert_response_message(response_get_cart, expected_message)
             assert_content_type(response_get_cart, "application/json")
 
-        with step("Generation data for adding to the shopping cart"):
-            items_to_add = [
-                {"productId": "ad0ef2b7-816b-4a11-b361-dfcbe705fc96", "productQuantity": 2},
-                {"productId": "3ea8e601-24c9-49b1-8c65-8db8b3a5c7a3", "productQuantity": 3}
-            ]
-
         with step("Adding products to the shopping cart "):
             CartAPI().add_new_item_to_cart(token=token,
-                                           items=items_to_add)
+                                           items=data_for_adding_product_to_cart)
 
         with step("Checking: 1. The shopping cart created under new user. 2.Added products are in the shopping cart"):
             response_get_cart_after_add = CartAPI().get_user_cart(token=token)
             expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
             assert_that(expected_user_id_in_cart), is_(new_user_id)
             product_list_after_add = get_product_info(response=response_get_cart_after_add)
-            assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
+            assert_compare_product_to_add_with_response(data_for_adding_product_to_cart, product_list_after_add)
 
         with step("Generating data for delete"):
             item_to_delete_more_than_one = get_item_id(response_get_cart_after_add)
-
-        with step("Deleting items from the shopping cart"):
             response_delete_item = CartAPI().delete_item_from_cart(token=token,
-                                                                   item_to_delete=item_to_delete_more_than_one)
-            print(response_delete_item.json()["closedAt"])
+                                                                   cart_item_id=item_to_delete_more_than_one)
 
         with step("Checking the response and Content-Type"):
             assert_content_type(response_delete_item, "application/json")
-
-

--- a/tests/cart/test_delete_items_from_cart.py
+++ b/tests/cart/test_delete_items_from_cart.py
@@ -4,8 +4,8 @@ from hamcrest import assert_that, is_
 from framework.asserts.common import assert_response_message, assert_content_type
 from framework.endpoints.cart_api import CartAPI
 from framework.endpoints.users_api import UsersAPI
-from framework.tools.methods_to_cart import verify_products_in_response, \
-    assert_compare_product_to_add_with_response, extract_item_id
+from framework.tools.methods_to_cart import get_product_info, \
+    assert_compare_product_to_add_with_response, get_item_id
 
 
 @feature("Deleting items from cart ")
@@ -16,8 +16,9 @@ class TestCart:
         "WHEN user delete ALL items from  cart"
         "THEN status HTTP CODE = 200"
     )
-    def test_deleting_item_from_cart(self, creating_user_via_api):
-        token, new_user_id = creating_user_via_api
+    def test_deleting_item_from_cart(self, create_and_delete_user_via_api):
+        with step("Registration of user"):
+            token, new_user_id = create_and_delete_user_via_api
 
         with step("Get shopping cart of user and verify that user doesn't have a shopping cart"):
             response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
@@ -41,22 +42,18 @@ class TestCart:
             response_get_cart_after_add = CartAPI().get_user_cart(token=token)
             expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
             assert_that(expected_user_id_in_cart), is_(new_user_id)
-            product_list_after_add = verify_products_in_response(response=response_get_cart_after_add)
+            product_list_after_add = get_product_info(response=response_get_cart_after_add)
             assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
 
         with step("Generating data for delete"):
-            item_to_delete_more_than_one = extract_item_id(response_get_cart_after_add)
+            item_to_delete_more_than_one = get_item_id(response_get_cart_after_add)
 
         with step("Deleting items from the shopping cart"):
             response_delete_item = CartAPI().delete_item_from_cart(token=token,
-                                                                   body=item_to_delete_more_than_one)
+                                                                   item_to_delete=item_to_delete_more_than_one)
             print(response_delete_item.json()["closedAt"])
 
         with step("Checking the response and Content-Type"):
             assert_content_type(response_delete_item, "application/json")
 
-        with step("Deleting user"):
-            UsersAPI().delete_user(token=token)
-            response_get_user_after_del = UsersAPI().get_user(token=token)
-            assert_that(response_get_user_after_del.status_code, is_(401))
-            CartAPI().get_user_cart(token=token, expected_status_code=401)
+

--- a/tests/cart/test_delete_one_item.py
+++ b/tests/cart/test_delete_one_item.py
@@ -1,0 +1,60 @@
+from allure import description, step, title, feature
+from hamcrest import assert_that, is_
+
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+from framework.endpoints.users_api import UsersAPI
+from framework.tools.methods_to_cart import verify_products_in_response, \
+    assert_compare_product_to_add_with_response
+
+
+@feature("Deleting item from cart ")
+class TestCart:
+    @title("Test deleting item from new user's cart")
+    @description(
+        "GIVEN user is registered and does not have shopping cart"
+        "WHEN user delete item from the cart"
+        "THEN status HTTP CODE = 200"
+    )
+    def test_deleting_item_from_cart(self, creating_user_via_api):
+        token, new_user_id = creating_user_via_api
+
+        with step("Getting shopping cart of user"):
+            response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
+
+        with step("Checking the response body and Content-Type"):
+            expected_message = f'The shopping cart for the user with id = {new_user_id} is not found.'
+            assert_response_message(response_get_cart, expected_message)
+            assert_content_type(response_get_cart, "application/json")
+
+        with step("Generation data for adding to the shopping cart"):
+            items_to_add = [
+                {"productId": "ad0ef2b7-816b-4a11-b361-dfcbe705fc96", "productQuantity": 2},
+                {"productId": "3ea8e601-24c9-49b1-8c65-8db8b3a5c7a3", "productQuantity": 3}
+            ]
+
+        with step("Adding new product to a shopping cart "):
+            CartAPI().add_new_item_to_cart(token=token,
+                                           items=items_to_add)
+
+        with step("Verify: 1. The shopping cart created under new user. 2.added products are in a shopping cart"):
+            response_get_cart_after_add = CartAPI().get_user_cart(token=token)
+            expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
+            assert_that(expected_user_id_in_cart), is_(new_user_id)
+            product_list_after_add = verify_products_in_response(response=response_get_cart_after_add)
+            assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
+
+        with step("Generating data for delete"):
+            cart_id_one_item = response_get_cart_after_add.json()["items"][0]["id"]
+            item_to_delete = {'shoppingCartItemIds': [cart_id_one_item]}
+
+        with step("Deleting item from cart"):
+            response_delete_item = CartAPI().delete_item_from_cart(token=token,
+                                                                   body=item_to_delete)
+            assert_content_type(response_delete_item, "application/json")
+
+        with step("Deleting user"):
+            UsersAPI().delete_user(token=token)
+            response_get_user_after_del = UsersAPI().get_user(token=token)
+            assert_that(response_get_user_after_del.status_code, is_(401))
+            CartAPI().get_user_cart(token=token, expected_status_code=401)

--- a/tests/cart/test_delete_one_item.py
+++ b/tests/cart/test_delete_one_item.py
@@ -1,9 +1,9 @@
 from allure import description, step, title, feature
 from hamcrest import assert_that, is_
 
+from configs import data_for_adding_product_to_cart
 from framework.asserts.common import assert_response_message, assert_content_type
 from framework.endpoints.cart_api import CartAPI
-from framework.endpoints.users_api import UsersAPI
 from framework.tools.methods_to_cart import get_product_info, \
     assert_compare_product_to_add_with_response
 
@@ -28,29 +28,21 @@ class TestCart:
             assert_response_message(response_get_cart, expected_message)
             assert_content_type(response_get_cart, "application/json")
 
-        with step("Generation data for adding to the shopping cart"):
-            items_to_add = [
-                {"productId": "ad0ef2b7-816b-4a11-b361-dfcbe705fc96", "productQuantity": 2},
-                {"productId": "3ea8e601-24c9-49b1-8c65-8db8b3a5c7a3", "productQuantity": 3}
-            ]
-
-        with step("Adding new product to a shopping cart "):
+        with step("Adding new products to a shopping cart "):
             CartAPI().add_new_item_to_cart(token=token,
-                                           items=items_to_add)
+                                           items=data_for_adding_product_to_cart)
 
         with step("Verify: 1. The shopping cart created under new user. 2.added products are in a shopping cart"):
             response_get_cart_after_add = CartAPI().get_user_cart(token=token)
             expected_user_id_in_cart = response_get_cart_after_add.json()["userId"]
             assert_that(expected_user_id_in_cart), is_(new_user_id)
             product_list_after_add = get_product_info(response=response_get_cart_after_add)
-            assert_compare_product_to_add_with_response(items_to_add, product_list_after_add)
+            assert_compare_product_to_add_with_response(data_for_adding_product_to_cart, product_list_after_add)
 
         with step("Generating data for delete"):
-            cart_id_one_item = response_get_cart_after_add.json()["items"][0]["id"]
-            item_to_delete = {'shoppingCartItemIds': [cart_id_one_item]}
+            cart_id_one_item = [response_get_cart_after_add.json()["items"][0]["id"]]
 
         with step("Deleting item from cart"):
             response_delete_item = CartAPI().delete_item_from_cart(token=token,
-                                                                   item_to_delete=item_to_delete)
+                                                                   cart_item_id=cart_id_one_item)
             assert_content_type(response_delete_item, "application/json")
-

--- a/tests/cart/test_get_not_exist_shopping_cart.py
+++ b/tests/cart/test_get_not_exist_shopping_cart.py
@@ -1,0 +1,32 @@
+from allure import description, step, title, feature
+from hamcrest import assert_that, is_
+
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+from framework.endpoints.users_api import UsersAPI
+
+
+@feature("Getting shopping  cart")
+class TestCart:
+    @title("Getting shopping cart that does not exist")
+    @description(
+        "GIVEN user is registered and does not have shopping cart"
+        "WHEN user get the cart"
+        "THEN status HTTP CODE = 404"
+    )
+    def test_get_user_cart(self, creating_user_via_api):
+        token, user_id = creating_user_via_api
+
+        with step("Get cart of user and verify that user doesn't have a shopping cart"):
+            response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
+
+        with step("Checking response body and Content Type"):
+            expected_message = f'The shopping cart for the user with id = {user_id} is not found.'
+            assert_response_message(response_get_cart, expected_message)
+            assert_content_type(response_get_cart, "application/json")
+
+        with step("Deleting user"):
+            UsersAPI().delete_user(token=token)
+            response_after_del = UsersAPI().get_user(token=token)
+            assert_that(response_after_del.status_code, is_(401))
+

--- a/tests/cart/test_get_not_exist_shopping_cart.py
+++ b/tests/cart/test_get_not_exist_shopping_cart.py
@@ -12,10 +12,11 @@ class TestCart:
     @description(
         "GIVEN user is registered and does not have shopping cart"
         "WHEN user get the cart"
-        "THEN status HTTP CODE = 404"
+        "THEN status HTTP CODE = 404 and the response body contains an appropriate error message."
     )
-    def test_get_user_cart(self, creating_user_via_api):
-        token, user_id = creating_user_via_api
+    def test_get_user_cart(self, create_and_delete_user_via_api):
+        with step("Registration of user"):
+            token, user_id = create_and_delete_user_via_api
 
         with step("Get cart of user and verify that user doesn't have a shopping cart"):
             response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
@@ -25,8 +26,5 @@ class TestCart:
             assert_response_message(response_get_cart, expected_message)
             assert_content_type(response_get_cart, "application/json")
 
-        with step("Deleting user"):
-            UsersAPI().delete_user(token=token)
-            response_after_del = UsersAPI().get_user(token=token)
-            assert_that(response_after_del.status_code, is_(401))
+
 

--- a/tests/cart/test_get_shopping_cart_with_incorrect_credential.py
+++ b/tests/cart/test_get_shopping_cart_with_incorrect_credential.py
@@ -42,7 +42,6 @@ class TestGetShoppingCart:
             data = generate_user_data(first_name_length=6, last_name_length=5, password_length=3)
             email = data["email"]
             expired_token = generate_jwt_token(email=email, expired=True)
-            # print(expired_token)
             response_get_cart = CartAPI().get_user_cart(token=expired_token, expected_status_code=401)
             assert_content_type(response_get_cart, "text/plain; charset=utf-8")
 
@@ -71,8 +70,8 @@ class TestGetShoppingCart:
         "WHEN the user sends a request to get information about shopping cart with blacklisted token, "
         "THEN the response code is 401 and the response body contains the error message"
     )
-    def test_getting_shopping_cart_with_blacklisted_token(self, creating_user_via_api):
-        token = creating_user_via_api
+    def test_getting_shopping_cart_with_blacklisted_token(self, create_and_delete_user_via_api):
+        token = create_and_delete_user_via_api
 
         with step("Logging out of user"):
             logging_out_response = AuthenticateAPI().logout(token=token)

--- a/tests/cart/test_get_shopping_cart_with_incorrect_credential.py
+++ b/tests/cart/test_get_shopping_cart_with_incorrect_credential.py
@@ -1,0 +1,127 @@
+import pytest
+from allure import feature, description, step, title
+from hamcrest import assert_that, is_
+
+from framework.asserts.common import (
+    assert_status_code,
+    assert_content_type,
+    assert_response_message,
+)
+from framework.endpoints.authenticate_api import AuthenticateAPI
+from framework.endpoints.cart_api import CartAPI
+from framework.tools.generators import generate_jwt_token
+from framework.tools.generators import generate_user, generate_user_data
+
+
+@feature("Getting shopping car")
+class TestGetShoppingCart:
+
+    @title("Getting shopping cart with Invalid Token")
+    @description(
+        "GIVEN the user is registered, "
+        "WHEN the user sends a request to get  information about shopping cart using an invalid token, "
+        "THEN the response code is 401 and the response body contains an appropriate error message."
+    )
+    @pytest.mark.skip(reason='Expected status code 401, found: 500')
+    def test_get_shopping_cart_info_with_invalid_token(self):
+        with step("Getting info about shopping cart"):
+            invalid_token = "invalid_token"
+            response_get_cart = CartAPI().get_user_cart(token=invalid_token, expected_status_code=401)
+
+        with step("Checking the Content-Type"):
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+    @title("Getting info about shopping cart with Expired Token")
+    @description(
+        "GIVEN the user is registered, "
+        "WHEN the user sends a request to get information about shopping cart with expired token, "
+        "THEN the response code is 401 and the response body contains the error message"
+    )
+    def test_getting_shopping_cart_with_expired_token(self):
+        with step("Getting info about shopping cart"):
+            data = generate_user_data(first_name_length=6, last_name_length=5, password_length=3)
+            email = data["email"]
+            expired_token = generate_jwt_token(email=email, expired=True)
+            # print(expired_token)
+            response_get_cart = CartAPI().get_user_cart(token=expired_token, expected_status_code=401)
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+        with step("Checking the response body"):
+            expected_error_message = "Jwt token is expired"
+            assert_response_message(response_get_cart, expected_error_message)
+
+    @title("Getting info about shopping cart with Empty Token")
+    @description(
+        "GIVEN the user is registered, "
+        "WHEN the user sends a request to get information about shopping cart with empty token, "
+        "THEN the response code is 401 and the response body contains the error message"
+    )
+    def test_getting_shopping_cart_with_empty_token(self):
+        with step("Getting info about shopping cart"):
+            response_get_cart = CartAPI().get_user_cart(token=" ", expected_status_code=401)
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+        with step("Checking the response body"):
+            expected_error_message = "Bearer authentication header is absent"
+            assert_response_message(response_get_cart, expected_error_message)
+
+    @title("Getting  Information about shopping cart with Blacklisted Token")
+    @description(
+        "GIVEN the user is logged out, "
+        "WHEN the user sends a request to get information about shopping cart with blacklisted token, "
+        "THEN the response code is 401 and the response body contains the error message"
+    )
+    def test_getting_shopping_cart_with_blacklisted_token(self, creating_user_via_api):
+        token = creating_user_via_api
+
+        with step("Logging out of user"):
+            logging_out_response = AuthenticateAPI().logout(token=token)
+            assert_that(
+                logging_out_response.status_code,
+                is_(200),
+                reason='Failed request "logout"',
+            )
+
+        with step("Getting  info about shopping cart"):
+            response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=401)
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+        with step("Checking the response body"):
+            expected_error_message = "JWT Token is blacklisted"
+            assert_response_message(response_get_cart, expected_error_message)
+
+    @title("Getting Info about shopping cart with Missing Email in Token")
+    @description(
+        "GIVEN the user is created "
+        "WHEN the user sends a request to get information about  shopping cart with token not containing email, "
+        "THEN the response code is 401 and the response body contains the error message"
+    )
+    def test_getting_shopping_cart_with_token_not_containing_email(self):
+        with step("Getting information about shopping cart "):
+            token_without_email = generate_jwt_token()
+            response_get_cart = CartAPI().get_user_cart(token=token_without_email, expected_status_code=401)
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+        with step("Checking the response body"):
+            expected_error_message = "User email not found in jwtToken"
+            assert_response_message(response_get_cart, expected_error_message)
+
+    @title("Getting information about shopping cart with Token of Non-Existing User")
+    @description(
+        "GIVEN the user is logged in, "
+        "WHEN the user sends a request to get information about shopping cart with token of non-existing user, "
+        "THEN the response code is 401 and the response body contains the error message"
+    )
+    def test_getting_shopping_cart_with_token_not_containing_correct_user_email(self):
+        with step("Getting information about shopping cart"):
+            email_of_non_existing_user = generate_user()["email"]
+            token_of_non_existing_user = generate_jwt_token(email_of_non_existing_user)
+            response_get_cart = CartAPI().get_user_cart(token=token_of_non_existing_user, expected_status_code=401)
+
+        with step("Checking response code and Content Type"):
+            assert_status_code(response_get_cart, 401)
+            assert_content_type(response_get_cart, "text/plain; charset=utf-8")
+
+        with step("Checking the response body"):
+            expected_error_message = "User with the provided email does not exist"
+            assert_response_message(response_get_cart, expected_error_message)

--- a/tests/cart/test_update_item_in_shopping_cart.py
+++ b/tests/cart/test_update_item_in_shopping_cart.py
@@ -1,0 +1,59 @@
+from allure import description, step, title, feature
+from hamcrest import assert_that, is_, equal_to
+
+from configs import data_for_not_exist_shopping_cart_item_id, data_for_adding_product_to_cart
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+from framework.tools.methods_to_cart import assert_compare_product_to_add_with_response, \
+    get_product_info, extract_random_item_detail, get_quantity_specific_cart_item
+
+
+@feature("Updating item quantity in cart ")
+class TestCart:
+    @title("Test updating item quantity in new user's cart")
+    @description(
+        "GIVEN user is registered and have shopping cart"
+        "WHEN user update item quantity in the shopping cart"
+        "THEN status HTTP CODE = 200 and response body that contain updated 'productQuantity' returns"
+    )
+    def test_updating_increase_item_quantity_in_cart(self, creating_and_adding_product_to_shopping_cart):
+        with step("Registration new user, and add product to the shopping cart"
+                  "Getting info about user and user's shopping cart "):
+            token, new_user_id, response_get_cart_after_added = creating_and_adding_product_to_shopping_cart
+
+        with step("Getting random items to update from shopping cart and determination quantity for update "):
+            random_item_from_cart = extract_random_item_detail(response_get_cart_after_added)
+            item_id_to_update = random_item_from_cart["id"]
+            item_quantity_before_update = random_item_from_cart["productQuantity"]
+            quantity_to_update = 1
+
+        with step("Update quantity of item"):
+            response_after_update = CartAPI().update_quantity_product(token=token, item_id=item_id_to_update,
+                                                                      item_quantity=quantity_to_update)
+
+        with step("Verify that quantity of item is updated"):
+            actual_item_quantity_after_update = get_quantity_specific_cart_item(response_after_update,
+                                                                                item_id_to_update)
+            expected_item_quantity_after_update = item_quantity_before_update + quantity_to_update
+            assert_that(expected_item_quantity_after_update, equal_to(actual_item_quantity_after_update))
+
+    def test_updating_decrease_item_quantity_in_cart(self, creating_and_adding_product_to_shopping_cart):
+        with step("Registration new user, and add product to the shopping cart"
+                  "Getting info about user and user's shopping cart "):
+            token, new_user_id, response_get_cart_after_added = creating_and_adding_product_to_shopping_cart
+
+        with step("Getting random items to update from shopping cart and determination quantity for update "):
+            random_item_from_cart = extract_random_item_detail(response_get_cart_after_added)
+            item_id_to_update = random_item_from_cart["id"]
+            item_quantity_before_update = random_item_from_cart["productQuantity"]
+            quantity_to_update = -1
+
+        with step("Update quantity of item"):
+            response_after_update = CartAPI().update_quantity_product(token=token, item_id=item_id_to_update,
+                                                                      item_quantity=quantity_to_update)
+
+        with step("Verify that quantity of item is updated"):
+            actual_item_quantity_after_update = get_quantity_specific_cart_item(response_after_update,
+                                                                                item_id_to_update)
+            expected_item_quantity_after_update = item_quantity_before_update + quantity_to_update
+            assert_that(expected_item_quantity_after_update, equal_to(actual_item_quantity_after_update))

--- a/tests/cart/test_update_not_existed_item_in_shopping_cart.py
+++ b/tests/cart/test_update_not_existed_item_in_shopping_cart.py
@@ -1,0 +1,35 @@
+from allure import description, step, title, feature
+
+from configs import data_for_not_exist_shopping_cart_item_id
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.endpoints.cart_api import CartAPI
+
+
+@feature("Updating NOT existing item's quantity in cart ")
+class TestCart:
+    @title("Test updating NOT existing item quantity in user's shopping cart")
+    @description(
+        "GIVEN user is registered and have shopping cart"
+        "WHEN user try to update not exist item's quantity in the shopping cart"
+        "THEN status HTTP CODE = 404 and response body that contain appropriate error message returns"
+    )
+    def test_updating_not_exist_item_in_cart(self, creating_and_adding_product_to_shopping_cart):
+        with step("Registration new user, and add product to the shopping cart"
+                  "Getting info about user and user's shopping cart "):
+            token, new_user_id, response_get_cart_after_added = creating_and_adding_product_to_shopping_cart
+
+        with step("Update quantity of product"):
+            data_for_update_not_exist_item = data_for_not_exist_shopping_cart_item_id
+            response_after_update = CartAPI().update_quantity_product(token=token,
+                                                                      item_id=data_for_update_not_exist_item[
+                                                                          "shoppingCartItemId"],
+                                                                      item_quantity=data_for_update_not_exist_item[
+                                                                          "productQuantityChange"],
+                                                                      expected_status_code=404)
+
+        with step("Checking the response body and the Content-Type"):
+            expected_message_after_update = "The shopping cart item with shoppingCartItemId = ec39b8c6-ba83-4f0a-8332-0769be35d5f9 is not found."
+            assert_response_message(response_after_update, expected_message_after_update)
+            assert_content_type(response_after_update, "application/json")
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,16 @@ from hamcrest import assert_that, is_
 from psycopg2 import connect
 from pytest import fixture
 
-from configs import DB_NAME, HOST_DB, PORT_DB, DB_USER, DB_PASS, HOST
+from configs import DB_NAME, HOST_DB, PORT_DB, DB_USER, DB_PASS, HOST, data_for_adding_product_to_cart
 from framework.endpoints.cart_api import CartAPI
 from framework.endpoints.users_api import UsersAPI
 from framework.queries.postgres_db import PostgresDB
 from framework.endpoints.authenticate_api import AuthenticateAPI
 from framework.tools.generators import generate_user, generate_user_data
 from framework.tools.logging import log_request
+from framework.asserts.common import assert_response_message, assert_content_type
+from framework.tools.methods_to_cart import assert_compare_product_to_add_with_response, \
+    get_product_info, get_item_id
 
 # Connection configuration
 PostgresDB.dbname = DB_NAME
@@ -111,3 +114,34 @@ def create_and_delete_user_via_api():
 
     with step("Deleting user"):
         UsersAPI().delete_user(token=token)
+
+
+@fixture(scope='function')
+def creating_and_adding_product_to_shopping_cart(create_and_delete_user_via_api):
+    with step("Registration of user"):
+        token, new_user_id = create_and_delete_user_via_api
+
+    with step("Get shopping cart of user and verify that user doesn't have a shopping cart"):
+        response_get_cart = CartAPI().get_user_cart(token=token, expected_status_code=404)
+
+    with step("Checking the response body and the Content-Type"):
+        expected_message = f'The shopping cart for the user with id = {new_user_id} is not found.'
+        assert_response_message(response_get_cart, expected_message)
+        assert_content_type(response_get_cart, "application/json")
+
+    with step("Generation data for adding to the shopping cart"):
+        items_to_add = data_for_adding_product_to_cart
+
+    with step("Adding new product to a shopping cart "):
+        CartAPI().add_new_item_to_cart(token=token,
+                                       items=items_to_add)
+
+    with step("Checking: 1. The shopping cart created under new user. 2.Added products are in a shopping cart"):
+        response_get_cart_after_added = CartAPI().get_user_cart(token=token)
+        expected_user_id_in_cart = response_get_cart_after_added.json()["userId"]
+        assert_that(expected_user_id_in_cart), is_(new_user_id)
+        product_list_after_added = get_product_info(response=response_get_cart_after_added)
+        assert_compare_product_to_add_with_response(items_to_add, product_list_after_added)
+        assert_content_type(response_get_cart, "application/json")
+
+        yield token, new_user_id, response_get_cart_after_added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def create_authorized_user(postgres):
 
 
 @fixture(scope="function")
-def creating_user_via_api():
+def create_and_delete_user_via_api():
     """Creating and authorizing a user via API """
     with step("Generation data for registration"):
         data = generate_user_data(
@@ -107,4 +107,7 @@ def creating_user_via_api():
         getting_user_response = UsersAPI().get_user(token=token)
         new_user_id = getting_user_response.json()["id"]
 
-    return token, new_user_id
+    yield token, new_user_id
+
+    with step("Deleting user"):
+        UsersAPI().delete_user(token=token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,16 @@
+import requests
 from allure import title, step
+from hamcrest import assert_that, is_
 from psycopg2 import connect
 from pytest import fixture
 
-from configs import DB_NAME, HOST_DB, PORT_DB, DB_USER, DB_PASS
+from configs import DB_NAME, HOST_DB, PORT_DB, DB_USER, DB_PASS, HOST
+from framework.endpoints.cart_api import CartAPI
+from framework.endpoints.users_api import UsersAPI
 from framework.queries.postgres_db import PostgresDB
 from framework.endpoints.authenticate_api import AuthenticateAPI
-from framework.tools.generators import generate_user
+from framework.tools.generators import generate_user, generate_user_data
+from framework.tools.logging import log_request
 
 # Connection configuration
 PostgresDB.dbname = DB_NAME
@@ -80,3 +85,26 @@ def create_authorized_user(postgres):
 
     with step("Removing user from DB"):
         postgres.delete_user(user_to_create["id"])
+
+
+@fixture(scope="function")
+def creating_user_via_api():
+    """Creating and authorizing a user via API """
+    with step("Generation data for registration"):
+        data = generate_user_data(
+            first_name_length=8, last_name_length=8, password_length=8
+        )
+
+    with step("Registration new user"):
+        response_registration = AuthenticateAPI().registration(body=data)
+
+        assert_that(
+            response_registration.status_code, is_(201), reason="Expected status code 201"
+        )
+        token = response_registration.json()["token"]
+
+    with step("Getting user's info via API"):
+        getting_user_response = UsersAPI().get_user(token=token)
+        new_user_id = getting_user_response.json()["id"]
+
+    return token, new_user_id


### PR DESCRIPTION
Task's name:
[IL-239] Create API tests for endpoint "Cart"

Developer's full name:
Tetiana Perinha

Changes:

New: added API tests for endpoint Cart.
New: added API request method for endpoint Cart.
New: added method to work with data from endpoint Cart responses.
Modified: added API method 'Delete' to the file users_api.py.
Modified: added fixture to register user through API request to the file tests/conftest.py
Modified: removed @pytest.mark.skip from test_authentication_invalid_credential.py - reason = bag fixed